### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master 
-      - uses: elgohr/Publish-Docker-Github-Action@3.04
+      - uses: elgohr/Publish-Docker-Github-Action@v5
         name: Build latest version and publish to GitHub Registry
         with:
           name: mileschou/hexo


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore